### PR TITLE
Fix null type handling in NotificationSenderFactory

### DIFF
--- a/src/main/java/com/notifyme/service/NotificationSenderFactory.java
+++ b/src/main/java/com/notifyme/service/NotificationSenderFactory.java
@@ -21,6 +21,9 @@ public class NotificationSenderFactory {
         }
     }
     public NotificationSender getSender(String type) {
+        if (type == null) {
+            return null;
+        }
         return senderMap.get(type.toUpperCase());
     }
 }

--- a/src/test/java/com/notifyme/service/NotificationSenderFactoryTest.java
+++ b/src/test/java/com/notifyme/service/NotificationSenderFactoryTest.java
@@ -1,0 +1,54 @@
+package com.notifyme.service;
+
+import com.notifyme.dto.NotificationEventDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotificationSenderFactoryTest {
+
+    private NotificationSenderFactory factory;
+
+    static class DummySender implements NotificationSender {
+        private final String type;
+
+        DummySender(String type) {
+            this.type = type;
+        }
+
+        @Override
+        public void send(NotificationEventDTO event) {
+            // no-op
+        }
+
+        @Override
+        public String getType() {
+            return type;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        factory = new NotificationSenderFactory(Arrays.asList(
+                new DummySender("EMAIL"),
+                new DummySender("SMS")
+        ));
+        factory.init();
+    }
+
+    @Test
+    void returnsNullWhenTypeIsNull() {
+        NotificationSender sender = factory.getSender(null);
+        assertNull(sender);
+    }
+
+    @Test
+    void returnsSenderForKnownType() {
+        NotificationSender sender = factory.getSender("email");
+        assertNotNull(sender);
+        assertEquals("EMAIL", sender.getType());
+    }
+}


### PR DESCRIPTION
## Summary
- prevent `NotificationSenderFactory` from throwing `NullPointerException`
- add unit tests for `NotificationSenderFactory`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685474950adc83339904e60a5e4cf9bf